### PR TITLE
Fix for "vector subscript out of range" exception (#1621)

### DIFF
--- a/src/CppParser/Parser.cpp
+++ b/src/CppParser/Parser.cpp
@@ -4640,7 +4640,7 @@ ParserResult* ClangParser::ParseHeader(CppParserOptions* Opts)
     {
         auto parser = new Parser(Opts);
         parsers.push_back(parser);
-        std::vector<std::string> Header(&Headers[i], &Headers[i + 1]);
+        std::vector<std::string> Header{Headers[i]};
         if (i < Headers.size() - 1)
             delete parser->Parse(Header);
         else


### PR DESCRIPTION
- The Visual Studio C++ compiler does not allow to access Headers[i+1]
when i+1 points past the last element.
Doing so raises an exception when in
debug mode

Co-authored-by: Christian Kolek <Christian.Kolek@teamviewer.com>